### PR TITLE
Fixed issue where table alias is used in `FROM` in SQL query

### DIFF
--- a/ORM/Table.php
+++ b/ORM/Table.php
@@ -22,7 +22,7 @@ class Table extends AppModel {
 		if (is_array($id)) {
 			$alias = Hash::get($id, 'alias') ?: (Hash::get($id, 'table') ?: $this->alias);
 			$id['alias'] = Inflector::singularize(preg_replace('/Table$/', '', $alias));
-			$this->name = $this->alias = $this->alias($id['alias']);
+			$this->alias = $this->alias($id['alias']);
 			$schema = Hash::get($id, 'schema');
 
 			if ($schema !== null) {


### PR DESCRIPTION
### Problem:
CakePHP: 2.9.9
PHP: 7.0.12

When `Class A` extends `Table` from `Entity.ORM` and `Class B` has `belongsTo` association to `Class A`, performing SQL query in `Class B` would result table alias used as table name in SQL query. This is an issue if the `belongsTo` group name is not the same as associated model name.

E.g.
```
$belongsTo = [
    'AnotherUser' => [
            'className'  => 'User',
            'foreignKey' => 'another_user_id',
    ]
]
```

### Fix:
 Removed assigning alias to name